### PR TITLE
Homework kubernetes-intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# dibilder_platform
-dibilder Platform repository
+# kubernetes-intro
+1. Разобраны причины восстановления pods после удаления, описано в PR.
+2. Создан Dockerfile и помещен в директорию kubernetes-intro/web
+3. Создан манифест для web-pod и помещен в директорию kubernetes-intro
+4. Создан исправленный манифест для frontend-pod и помещен в директорию kubernetes-intro
+

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: dibilder/frontend_demo:1.0
+    name: frontend
+    resources: {}
+    env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1 # Версия API
+kind: Pod # Объект, который создаем
+metadata:
+    name: web # Название Pod
+    labels: # Метки в формате key: value
+        key: value
+spec: # Описание Pod
+    containers: # Описание контейнеров внутри Pod
+    - name: web # Название контейнера
+      image: dibilder/nginxfiles:1.0 # Образ из которого создается контейнер
+      volumeMounts:
+      - name: app
+        mountPath: /app
+    initContainers:
+    - name: init-myservice
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+      - name: app
+        mountPath: /app
+    volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+ARG UID=1001
+COPY files.conf /etc/nginx/conf.d/default.conf
+COPY files/. /app
+EXPOSE 8000


### PR DESCRIPTION
# Выполнено ДЗ № 1

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Пункт 1 Разобраны причины восстановления pods после удаления, описано ниже в PR.
 - Пункт 2 Создан Dockerfile и помещен в директорию kubernetes-intro/web
 - Пункт 3 Создан манифест для web-pod и помещен в директорию kubernetes-intro
 - Пункт 4 Создан исправленный манифест для frontend-pod и помещен в директорию kubernetes-intro

## Как запустить проект:
 - kubectl apply -f web-pod.yaml
 - kubectl apply -f frontend-pod-healthy.yaml

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8000/index.html

## PR checklist:
 - [x] Выставлен label с темой домашнего задания

## Причины восстановления pods:
В ns kube-system содержатся следующие поды: coredns, etcd, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler. 

Из них только coredns находится в deployment, и имеет replicaset. Coredns перезапускается, так как для него задано количество реплик = 1, и при удалении пода, k8s создает новый для соответствия количеству реплик. Полностью убить coredns можно, задав количество реплик = 0 с помощью kubectl -n kube-system scale deployment coredns --replicas=0 или kubectl edit replicasets coredns-5d78c9869d -n kube-system

Остальные поды же созданы как static pods, и запускаются напрямую с помощью kubelet. Их конфиги хранятся в директории /etc/kubernetes/manifests, в случае minikube, непосредственно в контейнере minikube. Поды с конфигурациями в этой директории будут запущены всегда, когда работает kubelet. С помощью команды kubectl get pods мы видим, т.н. mirror pod. И при удалении, по факту настоящий под не удаляется. Один из способов полностью убить один из этих компонентов, удалить .yml файл из директории с манифестами, удалить контейнер и перезапустить kubelet. 